### PR TITLE
frontroute changed to 16.x, other versions update

### DIFF
--- a/modules/frontend/src/main/scala/starter/App.scala
+++ b/modules/frontend/src/main/scala/starter/App.scala
@@ -2,13 +2,14 @@ package starter
 
 import com.raquo.laminar.api.L._
 import io.frontroute._
+import starter.components.PageLayout
+import org.scalajs.dom.document.querySelector
 
 object App {
-
   def main(args: Array[String]): Unit = {
-    val _ = documentEvents.onDomContentLoaded.foreach { _ =>
-      LinkHandler.install()
-      Routes.start()
-    }(unsafeWindowOwner)
+    render(
+      querySelector("#app"),
+      PageLayout(div(Routes())).amend(LinkHandler.bind)
+    ).asInstanceOf[Unit]
   }
 }

--- a/modules/frontend/src/main/scala/starter/Routes.scala
+++ b/modules/frontend/src/main/scala/starter/Routes.scala
@@ -2,8 +2,6 @@ package starter
 
 import com.raquo.laminar.api.L._
 import io.frontroute._
-import org.scalajs.dom.document
-import starter.components.PageLayout
 import starter.pages._
 
 import scala.concurrent.duration._
@@ -14,47 +12,26 @@ object Routes {
   private var counter = 0
   private val someVar: Var[String] = Var("this string is the initial value of the var")
 
-  private val (routeResult, route) = makeRoute[Element] { render =>
-    concat(
-      (pathEnd | path("index")) {
-        render { IndexPage() }
-      },
-      pathPrefix("pages") {
-        concat(
-          path("page-1") {
-            signal(someVar.signal) { something =>
-              render { Page1(something) }
-            }
-          },
-          (path("page-2") & historyState) { state =>
-            render { Page2(state) }
-          }
-        )
-      },
-      pathPrefix("page-with-tabs") {
-        (path(segment) | pathEnd.mapTo("tab-1")).signal { $tab =>
-          render { PageWithTabs($tab) }
-        }
-      },
-      path("page-with-params") {
-        (maybeParam("param-1").signal & maybeParam("param-2").signal) { (param1, param2) =>
-          render { PageWithParams(param1, param2) }
-        }
-      },
-      render { PageNotFound() }
-    )
-  }
+  private val route = firstMatch(
+    (pathEnd | path("index")) { IndexPage.apply() },
+    pathPrefix("pages") { firstMatch(
+        path("page-1") { signal(someVar.signal) { something => Page1(something) }},
+        (path("page-2") & historyState) { state => Page2(state) }
+    )},
+    pathPrefix("page-with-tabs") {
+      (path(segment) | pathEnd.mapTo("tab-1")).signal { $tab => PageWithTabs($tab)}
+    },
+    path("page-with-params") { (maybeParam("param-1").signal & maybeParam("param-2").signal) {
+        (param1, param2) => PageWithParams(param1, param2)
+    }},
+    (noneMatched & extractUnmatchedPath) { unmatched => PageNotFound(unmatched) },
+  )
 
-  private val currentRender = routeResult.map(_.getOrElse(div("initializing...")))
-
-  def start(): Unit = {
-    val container = document.getElementById("app-container")
-    runRoute(route, LocationProvider.browser(windowEvents.onPopState))(unsafeWindowOwner)
-    BrowserNavigation.emitPopStateEvent()
-    val _ = render(container, PageLayout(currentRender))
+  def apply() = {
     val _ = setInterval(3.seconds) {
       counter = counter + 1
       someVar.writer.onNext(s"this is an updated value inside the var: $counter")
     }
+    route
   }
 }

--- a/modules/frontend/src/main/scala/starter/components/PageLayout.scala
+++ b/modules/frontend/src/main/scala/starter/components/PageLayout.scala
@@ -11,41 +11,41 @@ object PageLayout {
       mods
     )
 
-  def apply($child: Signal[Element]): HtmlElement =
-    div(
-      cls := "container mx-auto mt-4",
-      div(
-        cls := "px-4 py-4  bg-gray-800 flex items-baseline space-x-8",
-        navLink(
-          "/index",
-          cls := "text-gray-300",
-          "Index Page"
-        ),
-        navLink(
-          "/pages/page-1",
-          cls := "text-gray-300",
-          "Page 1"
-        ),
-        navLink(
-          "/pages/page-2",
-          cls := "text-gray-300",
-          "Page 2"
-        ),
-        navLink(
-          "/page-with-tabs",
-          cls := "text-gray-300",
-          "Page with Tabs"
-        ),
-        navLink(
-          "/page-with-params",
-          cls := "text-gray-300",
-          "Page with Params"
-        )
+  private def menu() = div(
+      cls := "px-4 py-4  bg-gray-800 flex items-baseline space-x-8",
+      navLink(
+        "/index",
+        cls := "text-gray-300",
+        "Index Page"
       ),
-      div(
-        cls := "bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10",
-        child <-- $child
+      navLink(
+        "/pages/page-1",
+        cls := "text-gray-300",
+        "Page 1"
+      ),
+      navLink(
+        "/pages/page-2",
+        cls := "text-gray-300",
+        "Page 2"
+      ),
+      navLink(
+        "/page-with-tabs",
+        cls := "text-gray-300",
+        "Page with Tabs"
+      ),
+      navLink(
+        "/page-with-params",
+        cls := "text-gray-300",
+        "Page with Params"
       )
     )
 
+  def apply($child: Element): HtmlElement = div(
+    cls := "container mx-auto mt-4",
+    menu(),
+    div(
+      cls := "bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10",
+      $child
+    )
+  )
 }

--- a/modules/frontend/src/main/scala/starter/pages/PageNotFound.scala
+++ b/modules/frontend/src/main/scala/starter/pages/PageNotFound.scala
@@ -4,10 +4,10 @@ import com.raquo.laminar.api.L._
 
 object PageNotFound {
 
-  def apply(): HtmlElement =
+  def apply(path: List[String]): HtmlElement =
     div(
       cls := "text-3xl font-bold text-indigo-900",
-      "Oops, Not Found"
+      s"""Oops, Not Found /${path.mkString("/")}"""
     )
 
 }

--- a/modules/frontend/src/main/static/html/index.html.ejs
+++ b/modules/frontend/src/main/static/html/index.html.ejs
@@ -8,7 +8,7 @@
 </head>
 
 <body>
-  <div id="app-container"></div>
+  <div id="app"></div>
 </body>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "compression-webpack-plugin": "^7.1.2",
     "concat-with-sourcemaps": "^1.1.0",
     "copy-webpack-plugin": "^8.1.1",
+    "cross-env": "^7.0.3",
     "css-loader": "^5.2.4",
     "cssnano": "^5.0.2",
     "file-loader": "^6.2.0",
@@ -35,9 +36,10 @@
     "defaults"
   ],
   "scripts": {
-    "dev": "TAILWIND_DISABLE_TOUCH=1 DEBUG=1 webpack serve --progress",
+    "dev": "cross-env TAILWIND_DISABLE_TOUCH=1 DEBUG=1 webpack serve --progress",
     "build": "webpack --progress",
     "build:dev": "webpack --progress",
     "start:prod": "webpack serve --progress"
-  }
+  },
+  "dependencies": {}
 }

--- a/project/DependencyVersions.scala
+++ b/project/DependencyVersions.scala
@@ -1,8 +1,11 @@
 object DependencyVersions {
 
-  val scala = "2.13.6"
-  val laminar = "0.13.0"
-  val frontroute = "0.13.2"
-  val scribe = "3.5.5"
+  val scala = "2.13.10"
+
+  val laminar = "0.14.5"
+
+  val frontroute = "0.16.1"
+
+  val scribe = "3.10.4"
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.3
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.11.0")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.17")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")

--- a/yarn.lock
+++ b/yarn.lock
@@ -890,15 +890,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001181, caniuse-lite@^1.0.30001196:
-  version "1.0.30001204"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz#256c85709a348ec4d175e847a3b515c66e79f2aa"
-  integrity sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==
-
-caniuse-lite@^1.0.30001219:
-  version "1.0.30001223"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001223.tgz#39b49ff0bfb3ee3587000d2f66c47addc6e14443"
-  integrity sha512-k/RYs6zc/fjbxTjaWZemeSmOjO0JJV+KguOBA3NwPup8uzxM1cMhR2BD9XmO86GuqaqTCO8CgkgH9Rz//vdDiA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001181, caniuse-lite@^1.0.30001196, caniuse-lite@^1.0.30001219:
+  version "1.0.30001431"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz"
+  integrity sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==
 
 chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -1170,7 +1165,14 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cross-spawn@^7.0.3:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
Please, help to migrate the example to frontroute 16.x.
I didn't understand what to do with PopState, so I left it commented out:
https://github.com/vtitov/frontroute-example/blob/frontroute-v16/modules/frontend/src/main/scala/starter/Routes.scala#L40